### PR TITLE
tests_l2: Fix typo in gpu clinfo build

### DIFF
--- a/tests/l2/dgpu/clinfo_build.yaml
+++ b/tests/l2/dgpu/clinfo_build.yaml
@@ -23,18 +23,18 @@ spec:
     dockerfile: |
         FROM registry.access.redhat.com/ubi8-minimal:latest 
 
-        ARG OCL_CID_VERSION=ocl-icd-2.2.12-1.el7.x86_64
+        ARG OCL_ICD_VERSION=ocl-icd-2.2.12-1.el7.x86_64
         ARG CLINFO_VERSION=clinfo-2.2.18.04.06-6.fc34.x86_64
 
         RUN microdnf install -y \
           glibc \
           yum-utils 
         
-        # install intel-opencl, ocl-cid and clinfo
+        # install intel-opencl, ocl-icd and clinfo
         RUN dnf install -y 'dnf-command(config-manager)' && \
           dnf config-manager --add-repo https://repositories.intel.com/graphics/rhel/8.4/intel-graphics.repo && \
           dnf install -y intel-opencl  \
-          https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/o/$OCL_CID_VERSION.rpm \
+          https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/o/$OCL_ICD_VERSION.rpm \
           http://rpmfind.net/linux/fedora/linux/releases/34/Everything/x86_64/os/Packages/c/$CLINFO_VERSION.rpm && \
           dnf clean all && dnf autoremove && rm -rf /var/lib/dnf/lists/*        
   strategy:
@@ -42,7 +42,7 @@ spec:
     noCache: true
     dockerStrategy:
       buildArgs:
-          - name: "OCL_CID_VERSION"
+          - name: "OCL_ICD_VERSION"
             value: "ocl-icd-2.2.12-1.el7.x86_64"
           - name: "CLINFO_VERSION"
             value: "clinfo-2.2.18.04.06-6.fc34.x86_64"


### PR DESCRIPTION
fix typo from 'ocl-cid' to 'ocl-icd' in  gpu's clinfo build yaml
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>