### PR TITLE
kmmo: Set imagePullPolicy to Always in on-premise build mode module

### DIFF
--- a/kmmo/intel-dgpu-on-premise-build-mode.yaml
+++ b/kmmo/intel-dgpu-on-premise-build-mode.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   moduleLoader:
     container:
+      imagePullPolicy: Always
       modprobe:
         moduleName: i915
         firmwarePath: /firmware


### PR DESCRIPTION
Set `.spec.moduleLoader.container.imagePullPolicy` to `Always` so KMM will always pull the latest image that is built by on-premise mode.
For more details about image pull policy, visit https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
Signed-off-by: Hersh Pathak hersh.pathak@intel.com