### PR TITLE
tests_l2: Update sgx l2 test

### DIFF
--- a/tests/l2/sgx/sgx_build.yaml
+++ b/tests/l2/sgx/sgx_build.yaml
@@ -23,8 +23,8 @@ spec:
     dockerfile: |
         FROM registry.access.redhat.com/ubi8/ubi AS builder
 
-        ARG SGX_SDK=sgx_linux_x64_sdk_2.18.101.1.bin
-        ARG LINUX_SGX_VERSION=2.18.1
+        ARG SGX_SDK=sgx_linux_x64_sdk_2.19.100.3.bin
+        ARG LINUX_SGX_VERSION=2.19
 
         RUN dnf -y update && \
           dnf -y install \
@@ -42,7 +42,6 @@ spec:
             && echo "yes" | ./$SGX_SDK \
             && rm $SGX_SDK
 
-        WORKDIR /opt/intel
         RUN cd sgxsdk/SampleCode/SampleEnclave \
             && . /opt/intel/sgxsdk/environment \
             && make 
@@ -56,21 +55,21 @@ spec:
             gzip && \
             microdnf clean all && rm -rf /var/cache/dnf
 
-        # Download SGX PSW and install SGX runtime components
+        # Download SGX PSW and install SGX runtime components to create SGX enclave
         WORKDIR /opt/intel
         RUN wget https://download.01.org/intel-sgx/latest/linux-latest/distro/rhel8.6-server/sgx_rpm_local_repo.tgz \ 
             && sha256sum sgx_rpm_local_repo.tgz \
             && tar xvf sgx_rpm_local_repo.tgz \
             && rm -rf sgx_rpm_local_repo.tgz
 
-        RUN cd /opt/intel/sgx_rpm_local_repo && rpm -i \
+        RUN cd sgx_rpm_local_repo && rpm -i \
             libsgx-headers-$LINUX_SGX_VERSION* \
             libsgx-enclave-common-$LINUX_SGX_VERSION* \
             libsgx-urts-$LINUX_SGX_VERSION* && \
             rm -r /opt/intel/sgx_rpm_local_repo
 
-        COPY --from=builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/app /opt/intel/app
-        COPY --from=builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/enclave.signed.so /opt/intel/enclave.signed.so
+        COPY --from=builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/app app
+        COPY --from=builder /opt/intel/sgxsdk/SampleCode/SampleEnclave/enclave.signed.so enclave.signed.so
 
         ENTRYPOINT /opt/intel/app  
    
@@ -80,9 +79,9 @@ spec:
     dockerStrategy:
       buildArgs:
           - name: "SGX_SDK"
-            value: "sgx_linux_x64_sdk_2.18.101.1.bin"
+            value: "sgx_linux_x64_sdk_2.19.100.3.bin"
           - name: "LINUX_SGX_VERSION"
-            value: "2.18.1"
+            value: "2.19"
   output:
     to:
       kind: ImageStreamTag

--- a/tests/l2/sgx/sgx_job.yaml
+++ b/tests/l2/sgx/sgx_job.yaml
@@ -13,7 +13,7 @@ spec:
       containers: 
         - name: intel-sgx-job
           image: image-registry.openshift-image-registry.svc:5000/intel-sgx/intel-sgx-workload:latest
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           workingDir: "/opt/intel/"
           command: ["/opt/intel/app"]
           resources:


### PR DESCRIPTION
- Update linux sgx version from 2.18.1 to [latest 2.19](https://github.com/intel/linux-sgx/releases/tag/sgx_2.19)
- Optimize workdir for sgx build
- Change imagepullpolicy to always- always pulls latest image (In case image present on node and has changed)
- Verified on 4.12.6
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>