### PR TITLE
Makefile: Added makefile to simplify Terrascan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+terrascan:
+	@ls */*.yaml | while read f ; \
+	do \
+		echo "==== $$f ====" ; \
+		terrascan scan -v --show-passed -d $$(dirname $$f) -i k8s --severity high \
+		--skip-rules 'AC_K8S_0051,AC_K8S_0076,AC_K8S_0087' \
+		|| exit $$? ; \
+	done > iocp-terrascan-result.txt
+
+clean-terrascan:
+	rm -rf iocp-terrascan-result.txt


### PR DESCRIPTION
Added Terrascan for scanning related yaml files in this project.

Usage: 
```
$ make terrascan
```
output: 
Scan results stored in the file `iocp-terrascan-results.txt`

Clean the output file using: 
```
$ make clean-terrascan
```

Signed-off-by: chaitanya1731 <chaitanya.kulkarni@intel.com>