### PR TITLE
tests_l2: Update readme

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -31,6 +31,10 @@ $ oc logs intel-sgx-job-4tnh5
 ```
 ### Verify Intel® Data Center GPU provisioning
 This workload runs [clinfo](https://github.com/Oblomov/clinfo) utilizing the i915 resource from GPU provisioning and displays the related GPU information.
+* To work around [issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/107), please run the below command on the node with the GPU where your workload will run:
+  
+```$ setsebool container_use_devices on```
+
 *	Build the workload container image. 
 
 ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/dgpu/clinfo_build.yaml ```


### PR DESCRIPTION
Updated readme for tests/l2/gpu- set boolean value of `setsebool container_use_devices on` for the GPU node. 
This is needed for GPU workloads to run and access host devices. Will be removed after https://github.com/intel/intel-technology-enabling-for-openshift/issues/107 resolved

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
