### PR TITLE
tests_l2: Add container_scc.yaml for dgpu workload

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -34,6 +34,12 @@ This workload runs [clinfo](https://github.com/Oblomov/clinfo) utilizing the i91
 
 *	Deploy and execute the workload.
 
+   For the container to use /dev folder on host, use the ```container_device_t``` selinux option with a custom SCC and service account as below.
+
+```$ oc adm policy add-scc-to-user container-scc -z container-scc```
+  
+```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/dgpu/container_scc.yaml```
+
 ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/dgpu/clinfo_job.yaml```
 
 * Check the results.

--- a/tests/l2/dgpu/clinfo_job.yaml
+++ b/tests/l2/dgpu/clinfo_job.yaml
@@ -11,10 +11,14 @@ spec:
     metadata:
     spec:
       restartPolicy: Never
+      serviceAccountName: container-scc
       containers:
       - name: clinfo-pod
         image: image-registry.openshift-image-registry.svc:5000/intel-dgpu/intel-dgpu-clinfo:latest
         command: ["clinfo"]
+        seLinuxContext:
+          seLinuxOptions:
+            type: container_device_t
         resources:
           limits:
             gpu.intel.com/i915: 1

--- a/tests/l2/dgpu/container_scc.yaml
+++ b/tests/l2/dgpu/container_scc.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: security.openshift.io/v1
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'SCC to use container_device_t seLinux option'
+  name: container-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  seLinuxOptions:
+    type: container_device_t
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - secret


### PR DESCRIPTION
Resolves https://github.com/intel/intel-technology-enabling-for-openshift/issues/107

- Add custom SCC using `container_device_t` for dgpu workloads to avoid using `setsebool container_use_devices on` on host node
- Update clinfo_job and README instructions for it.

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>