### PR TITLE
QAT: remove c6xxx and fix maxNumDevices

### DIFF
--- a/device_plugins/qat_device_plugin.yaml
+++ b/device_plugins/qat_device_plugin.yaml
@@ -10,9 +10,8 @@ spec:
   initImage: registry.connect.redhat.com/intel/intel-qat-initcontainer@sha256:c494debf7e3dc8be49ac7e634506db6892534c27f15b970954fff18310654dcb
   dpdkDriver: vfio-pci
   kernelVfDrivers:
-    - c6xxvf
     - 4xxxvf
-  maxNumDevices: 1
+  maxNumDevices: 128
   logLevel: 4
   nodeSelector:
     intel.feature.node.kubernetes.io/qat: "true"


### PR DESCRIPTION
Since We only support 4xxx qat devices, remove unsupported device. Set maxNumDevices to 128.
Signed-off-by: Manish Regmi <manish.regmi@intel.com>