### PR TITLE
nfd: Update node-feature-rules-openshift.yaml

### DIFF
--- a/nfd/node-feature-rules-openshift.yaml
+++ b/nfd/node-feature-rules-openshift.yaml
@@ -7,45 +7,6 @@ metadata:
   name: intel-dp-devices
 spec:
   rules:
-    - name: "intel.dlb"
-      labels:
-        "intel.feature.node.kubernetes.io/dlb": "true"
-      matchFeatures:
-        - feature: pci.device
-          matchExpressions:
-            vendor: {op: In, value: ["8086"]}
-            device: {op: In, value: ["2710"]}
-            class: {op: In, value: ["0b40"]}
-        - feature: kernel.loadedmodule
-          matchExpressions:
-            dlb2: {op: Exists}
-
-    - name: "intel.dsa"
-      labels:
-        "intel.feature.node.kubernetes.io/dsa": "true"
-      matchFeatures:
-        - feature: pci.device
-          matchExpressions:
-            vendor: {op: In, value: ["8086"]}
-            device: {op: In, value: ["0b25"]}
-            class: {op: In, value: ["0880"]}
-        - feature: kernel.loadedmodule
-          matchExpressions:
-            idxd: {op: Exists}
-
-    - name: "intel.fpga-arria10"
-      labels:
-        "intel.feature.node.kubernetes.io/fpga-arria10": "true"
-      matchFeatures:
-        - feature: pci.device
-          matchExpressions:
-            vendor: {op: In, value: ["8086"]}
-            device: {op: In, value: ["09c4"]}
-            class: {op: In, value: ["1200"]}
-        - feature: kernel.loadedmodule
-          matchExpressions:
-            dfl_pci: {op: Exists}
-
     - name: "intel.gpu"
       labels:
         "intel.feature.node.kubernetes.io/gpu": "true"
@@ -62,7 +23,7 @@ spec:
         - feature: pci.device
           matchExpressions:
             vendor: {op: In, value: ["8086"]}
-            device: {op: In, value: ["37c8", "4940"]}
+            device: {op: In, value: ["4940", "4942", "4944"]}
             class: {op: In, value: ["0b40"]}
         - feature: kernel.loadedmodule
           matchExpressions:


### PR DESCRIPTION
Keep node feature rules only for SGX, QAT, and GPU.
Keep only 4xxx device IDs for QAT as we support QAT only on SPR or later platforms.
Signed-off-by: Hersh Pathak hersh.pathak@intel.com