### PR TITLE
tests_l2: Added qat workload

### DIFF
--- a/tests/l2/qat/qatlib_build.yaml
+++ b/tests/l2/qat/qatlib_build.yaml
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: intel-qat-workload
+  namespace: intel-qat
+spec: {}
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: intel-qat-workload
+  namespace: intel-qat
+spec:
+  triggers:
+    - type: "ConfigChange"
+    - type: "ImageChange"
+  runPolicy: "Serial"
+  source:
+    type: Dockerfile
+    dockerfile: |
+        
+        FROM registry.access.redhat.com/ubi8/ubi 
+        ARG QATLIB_VERSION
+
+        RUN dnf -y update && \
+            dnf install -y gcc \
+              make \
+              automake \ 
+              autoconf \
+              libtool \
+              http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/nasm-2.15.03-3.el8.x86_64.rpm \
+              openssl-devel \
+              zlib-devel \
+              git && \
+              git clone -b $QATLIB_VERSION https://github.com/intel/qatlib
+            
+          RUN cd /qatlib && \
+              ./autogen.sh && \
+              ./configure \
+              --prefix=/usr \
+              --enable-systemd=no && \
+              make -j && \
+              make install samples-install
+
+          WORKDIR  /usr/bin
+          ENTRYPOINT  ["/usr/bin/cpa_sample_code"]
+  strategy:
+    type: Docker
+    noCache: true
+    dockerStrategy:
+      buildArgs:
+          - name: "QATLIB_VERSION"
+            value: "23.08.0"
+
+  output:
+    to:
+      kind: ImageStreamTag
+      name: intel-qat-workload:latest

--- a/tests/l2/qat/qatlib_job.yaml
+++ b/tests/l2/qat/qatlib_job.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: intel-qat-workload
+  namespace: intel-qat
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: intel-qat-job
+        image: image-registry.openshift-image-registry.svc:5000/intel-qat/intel-qat-workload:latest
+        imagePullPolicy: IfNotPresent
+        command: ["./cpa_sample_code"]
+        securityContext:
+          capabilities:
+            add:
+              [IPC_LOCK]
+        resources:
+          requests:
+            qat.intel.com/dc: '1'
+            qat.intel.com/cy: '1'
+          limits:
+            qat.intel.com/dc: '1'
+            qat.intel.com/cy: '1'
+      serviceAccount: intel-qat


### PR DESCRIPTION

tests_l2: Add qatlib based Intel QAT sample workload

- qatlib is built from source in https://github.com/intel/qatlib
- The qatlib version is specified by QATLIB_VERSION: 23.08.0
- cpa_sample_code shipped with qatlib is used to verify the QAT provisioning on OCP
Resources:
  - qat.intel.com/dc is used for QAT compression/decompression
  - qat.intel.com/cy is used for QAT asymmetric/asymmetric cryptography
- serviceAccount: intel-qat uses the user defined SCC intel-qat-scc which enables the IPC_LOCK capability for Qat-lib based workload see https://github.com/intel/intel-technology-enabling-for-openshift/issues/122


Signed-off-by: [veenadhari.bedida@intel.com](mailto:veenadhari.bedida@intel.com)
