### PR TITLE
device_plugins: Updated container image SHAs for 1.0.1 release

### DIFF
--- a/device_plugins/gpu_device_plugin.yaml
+++ b/device_plugins/gpu_device_plugin.yaml
@@ -6,8 +6,8 @@ kind: GpuDevicePlugin
 metadata:
   name: gpudeviceplugin-sample
 spec:
-  image: registry.connect.redhat.com/intel/intel-gpu-plugin@sha256:29d686b6cda943aa5814b23aabc9709983659613be61aed288e30b7ec579b767
-  initImage: registry.connect.redhat.com/intel/intel-gpu-initcontainer@sha256:a0a2422d5c4fb42947b2b69e353800b212cb221d6bbdfb7a5ed446258998df89
+  image: registry.connect.redhat.com/intel/intel-gpu-plugin@sha256:cfbdee9feb786d22492212be11e63d3c4095dca019a5a23cdff644f209c38fd6
+  initImage: registry.connect.redhat.com/intel/intel-gpu-initcontainer@sha256:5abcc534c54b21f52b96500c745b578be78288be1374e70f83af3a9363ddda0b
   preferredAllocationPolicy: none
   sharedDevNum: 1
   logLevel: 4

--- a/device_plugins/qat_device_plugin.yaml
+++ b/device_plugins/qat_device_plugin.yaml
@@ -6,8 +6,8 @@ kind: QatDevicePlugin
 metadata:
   name: qatdeviceplugin-sample
 spec:
-  image: registry.connect.redhat.com/intel/intel-qat-plugin@sha256:b3e3022314347d451042cf52123215eddf9d21059665d8a1d9c92c58e88c135c
-  initImage: registry.connect.redhat.com/intel/intel-qat-initcontainer@sha256:29653c807ba5335be84b3e54a723ecec9173d0f460e2ba07845af1c89e2f4376
+  image: registry.connect.redhat.com/intel/intel-qat-plugin@sha256:12ae366fd80710f73bfc91ab7398e17101ec0fdfcad4a4e6f8e473a6c13b2b3b
+  initImage: registry.connect.redhat.com/intel/intel-qat-initcontainer@sha256:c494debf7e3dc8be49ac7e634506db6892534c27f15b970954fff18310654dcb
   dpdkDriver: vfio-pci
   kernelVfDrivers:
     - c6xxvf

--- a/device_plugins/sgx_device_plugin.yaml
+++ b/device_plugins/sgx_device_plugin.yaml
@@ -6,8 +6,8 @@ kind: SgxDevicePlugin
 metadata:
   name: sgxdeviceplugin-sample
 spec:
-  image: registry.connect.redhat.com/intel/intel-sgx-plugin@sha256:60a8cf855383bd149822c48b7369540c3e806b0b77efdf0f4aac7831ce1bb1b2
-  initImage: registry.connect.redhat.com/intel/intel-sgx-initcontainer@sha256:18f0695fd5614c86e555423117c648be866f9b936fd1d2023c8949590fb549e3
+  image: registry.connect.redhat.com/intel/intel-sgx-plugin@sha256:0d0bc261a8d631c2021d0c2a41260a30444114686c8d31d34feae7cfdc650fb6
+  initImage: registry.connect.redhat.com/intel/intel-sgx-initcontainer@sha256:fe8997dee7f5b581817b2b050b074711ba2548ad1037116ba10daf86c918916c
   enclaveLimit: 110
   provisionLimit: 110
   logLevel: 4


### PR DESCRIPTION
Updated SHAs for SGX, GPU and QAT device plugins and initcontainer images for 1.0.1 release

Signed-off-by: chaitanya1731 <chaitanya.kulkarni@intel.com>