### PR TITLE
machine_configuration: remove extra "`" character in QAT machine config yaml

### DIFF
--- a/machine_configuration/100-intel-qat-intel-iommu-on.yaml
+++ b/machine_configuration/100-intel-qat-intel-iommu-on.yaml
@@ -14,4 +14,4 @@ spec:
   kernelArguments:
       - intel_iommu=on
   selector:
-    `intel.feature.node.kubernetes.io/qat: 'true'
+    intel.feature.node.kubernetes.io/qat: 'true'


### PR DESCRIPTION
Signed-off-by: Hersh Pathak hersh.pathak@intel.com