### PR TITLE
machine_configuration: add MCO to load vfio-pci driver at boot

### DIFF
--- a/machine_configuration/100-intel-qat-intel-iommu-on.yaml
+++ b/machine_configuration/100-intel-qat-intel-iommu-on.yaml
@@ -12,6 +12,6 @@ spec:
     ignition:
       version: 3.2.0
   kernelArguments:
-      - intel_iommu=on
+      - intel_iommu=on modules_load=vfio-pci vfio-pci.ids=8086:4941,8086:4943
   selector:
     intel.feature.node.kubernetes.io/qat: 'true'


### PR DESCRIPTION
machine_configuration: Load vfio-pci driver at boot via kernel boot Parameters

Signed-off-by: Manish Regmi <manish.regmi@intel.com>