### PR TITLE
tests_l2: Fix typo in readme

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -8,7 +8,7 @@ After provisioning Intel hardware features on RHOCP, the respective hardware res
 This [SampleEnclave](https://github.com/intel/linux-sgx/tree/master/SampleCode/SampleEnclave) application workload from the Intel SGX SDK runs an Intel SGX enclave utilizing the EPC resource from the Intel SGX provisioning.
 * Build the container image. 
   
-```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/ main/tests/l2/sgx/sgx_build.yaml```
+```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/sgx/sgx_build.yaml```
 
 * Deploy and run the workload.
   


### PR DESCRIPTION
tests_l2: Fix typo in readme
For sgx l2 test yaml

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
