### PR TITLE
Security: Adding intel-qat-scc for Intel QAT based workload

### DIFF
--- a/security/qatlib_scc.yaml
+++ b/security/qatlib_scc.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: security.openshift.io/v1
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: 
+- IPC_LOCK
+defaultAddCapabilities: null
+fsGroup:
+   type: MustRunAs
+groups: []
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'SCC for Intel QAT based workload'
+  name: intel-qat-scc
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- ALL
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+seccompProfiles:
+- runtime/default
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- ephemeral
+- persistentVolumeClaim
+- projected
+- secret


### PR DESCRIPTION
Security: Adding intel-qat-scc for Intel QAT based workload

This user-defined SCC is based on the [OCP predefined restricted-v2 SCC](https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html#default-sccs_configuring-internal-oauth)
The IPC_LOCK capability and RunAsAny permission are added to the restricted-v2 SCC for intel-qat-scc

This patch is used to fix https://github.com/intel/intel-technology-enabling-for-openshift/issues/122

Signed-off-by: vbedida79 [veenadhari.bedida@intel.com](mailto:veenadhari.bedida@intel.com)