### PR TITLE
security: Added qatlib_rbac.yaml

### DIFF
--- a/security/qatlib_rbac.yaml
+++ b/security/qatlib_rbac.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: intel-qat
+  namespace: intel-qat
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: intel-qat
+  namespace: intel-qat
+rules:
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  resourceNames:
+  - intel-qat-scc
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: intel-qat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: intel-qat
+subjects:
+- kind: ServiceAccount
+  name: intel-qat
+  namespace: intel-qat


### PR DESCRIPTION
security: Add qatlib rbac yaml to use custom SCC for IPC_LOCK and running container as root
refer to https://github.com/intel/intel-technology-enabling-for-openshift/pull/132

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
