### PR TITLE
tests_l2: Update qat workload commands in readme

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -67,17 +67,17 @@ $ oc logs intel-dgpu-clinfo-56mh2
 ### Verify Intel® QuickAssist Technology provisioning
 This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Refer to the [qatlib readme](https://github.com/intel/qatlib/blob/main/INSTALL) for more details. 
 
-*	Build the workload container image. 
+*	Build the workload container image
+  ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/qat/qatlib_build.yaml ```
 
-```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/qat/qatlib_build.yaml ```
+* Create SCC intel-qat-scc for Intel QAT based workload, if this SCC is not created   
+  ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/security/qatlib_scc.yaml```
+      
+* Create the intel-qat service account to use intel-qat-scc
+  ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/security/qatlib_rbac.yaml```
 
-*	Deploy and execute the workload.
-
-    * Run with IPC_LOCK capability for pod
-  
-```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/security/qatlib_rbac.yaml```
-
-```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/qat/qatlib_job.yaml```
+* Deploy the qatlib workload job with intel-qat service account
+  ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/qat/qatlib_job.yaml```
 
 * Check the results.
 ``` 


### PR DESCRIPTION
Update readme with qatlib workload commands based on https://github.com/intel/intel-technology-enabling-for-openshift/pull/137 and https://github.com/intel/intel-technology-enabling-for-openshift/pull/132