### PR TITLE
tests_l2: Added gpu hwinfo workload

### DIFF
--- a/tests/l2/dgpu/hwinfo_build.yaml
+++ b/tests/l2/dgpu/hwinfo_build.yaml
@@ -1,0 +1,40 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: intel-dgpu-hwinfo
+  namespace: intel-dgpu
+spec: {}
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: intel-dgpu-hwinfo
+  namespace: intel-dgpu
+spec:
+  triggers:
+    - type: "ConfigChange"
+    - type: "ImageChange"
+  runPolicy: "Serial"
+  source:
+    type: Dockerfile
+    dockerfile: | 
+        ARG BUILDER=registry.access.redhat.com/ubi9-minimal:latest
+        FROM ${BUILDER} 
+        RUN microdnf -y update && \
+          rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && \
+          microdnf install -y hwinfo
+        ENTRYPOINT  ["hwinfo"]
+  strategy:
+    type: Docker
+    noCache: true
+    dockerStrategy:
+      buildArgs:
+          - name: "BUILDER"
+            value: "registry.access.redhat.com/ubi9-minimal:latest"
+  output:
+    to:
+      kind: ImageStreamTag
+      name: intel-dgpu-hwinfo:latest

--- a/tests/l2/dgpu/hwinfo_job.yaml
+++ b/tests/l2/dgpu/hwinfo_job.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2023 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: intel-dgpu-hwinfo
+  namespace: intel-dgpu
+spec:
+  template:
+    metadata:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: hwinfo-pod
+        image: image-registry.openshift-image-registry.svc:5000/intel-dgpu/intel-dgpu-hwinfo:latest
+        command: ["hwinfo"]
+        args: ["--display"]
+        resources:
+          limits:
+            gpu.intel.com/i915: 1
+        imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Added GPU hwinfo ubi9 based workload for OCP 4.13
Based on [driver verification](https://dgpu-docs.intel.com/driver/installation.html#verify-install)
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
