### PR TITLE
kmmo: Remove in-tree i915 driver at runtime using KMM 1.1.1

### DIFF
--- a/kmmo/intel-dgpu-on-premise-build-mode.yaml
+++ b/kmmo/intel-dgpu-on-premise-build-mode.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   moduleLoader:
     container:
+      inTreeModuleToRemove: i915
       imagePullPolicy: Always
       modprobe:
         moduleName: i915

--- a/kmmo/intel-dgpu.yaml
+++ b/kmmo/intel-dgpu.yaml
@@ -9,6 +9,7 @@ metadata:
 spec:
   moduleLoader:
     container:
+      inTreeModuleToRemove: i915
       modprobe:
         moduleName: i915
         firmwarePath: /firmware


### PR DESCRIPTION
RHEL 9.2 has an in-tree i915 driver that needs to be unloaded before we can load the out of tree i915 driver for GPU provisioning on RHOCP. Signed-off-by: Hersh Pathak hersh.pathak@intel.com