### PR TITLE
tests_l2: updated sgx build to ubi9

### DIFF
--- a/tests/l2/sgx/sgx_build.yaml
+++ b/tests/l2/sgx/sgx_build.yaml
@@ -21,10 +21,13 @@ spec:
   source:
     type: Dockerfile
     dockerfile: |
-        FROM registry.access.redhat.com/ubi8/ubi AS builder
+        ARG BUILDER=registry.access.redhat.com/ubi9:latest 
+        ARG BASE=registry.access.redhat.com/ubi9-minimal:latest
+        ARG LINUX_SGX_VERSION=2.22
+        FROM ${BUILDER} AS builder
 
-        ARG SGX_SDK=sgx_linux_x64_sdk_2.19.100.3.bin
-        ARG LINUX_SGX_VERSION=2.19
+        ARG SGX_SDK=sgx_linux_x64_sdk_2.22.100.3.bin
+        ARG LINUX_SGX_VERSION
 
         RUN dnf -y update && \
           dnf -y install \
@@ -37,7 +40,7 @@ spec:
 
         # SGX SDK installed in /opt/intel directory
         WORKDIR /opt/intel
-        RUN wget https://download.01.org/intel-sgx/sgx-linux/$LINUX_SGX_VERSION/distro/rhel8.6-server/$SGX_SDK \
+        RUN wget https://download.01.org/intel-sgx/sgx-linux/$LINUX_SGX_VERSION/distro/rhel9.2-server/$SGX_SDK \
             && chmod +x  $SGX_SDK \
             && echo "yes" | ./$SGX_SDK \
             && rm $SGX_SDK
@@ -45,9 +48,8 @@ spec:
         RUN cd sgxsdk/SampleCode/SampleEnclave \
             && . /opt/intel/sgxsdk/environment \
             && make 
-
-        FROM registry.access.redhat.com/ubi8-minimal:latest
-
+        FROM ${BASE} 
+        ARG LINUX_SGX_VERSION
         RUN microdnf -y update && \
             microdnf -y install \
             wget \
@@ -57,7 +59,7 @@ spec:
 
         # Download SGX PSW and install SGX runtime components to create SGX enclave
         WORKDIR /opt/intel
-        RUN wget https://download.01.org/intel-sgx/latest/linux-latest/distro/rhel8.6-server/sgx_rpm_local_repo.tgz \ 
+        RUN wget https://download.01.org/intel-sgx/sgx-linux/$LINUX_SGX_VERSION/distro/rhel9.2-server/sgx_rpm_local_repo.tgz \
             && sha256sum sgx_rpm_local_repo.tgz \
             && tar xvf sgx_rpm_local_repo.tgz \
             && rm -rf sgx_rpm_local_repo.tgz
@@ -78,10 +80,14 @@ spec:
     noCache: true
     dockerStrategy:
       buildArgs:
+          - name: "BUILDER"
+            value: "registry.access.redhat.com/ubi9:9.2"
+          - name: "BASE"
+            value: "registry.access.redhat.com/ubi9-minimal:9.2"
           - name: "SGX_SDK"
-            value: "sgx_linux_x64_sdk_2.19.100.3.bin"
+            value: "sgx_linux_x64_sdk_2.22.100.3.bin"
           - name: "LINUX_SGX_VERSION"
-            value: "2.19"
+            value: "2.22"
   output:
     to:
       kind: ImageStreamTag


### PR DESCRIPTION
- updated to ubi9.2 for rhel 9.2 on ocp 4.13
- sgx sdk and psw versions to latest 2.22 for rhel 9.2
- changed sgx psw url to match sgx sdk source url

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>


