### PR TITLE
tests_l2: Update qatlib workload to use its dnf package

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -113,7 +113,7 @@ $ oc logs intel-dgpu-hwinfo-l4572
 ```                        
 
 ### Verify Intel® QuickAssist Technology provisioning
-This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Refer to the [qatlib readme](https://github.com/intel/qatlib/blob/main/INSTALL) for more details. 
+This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Qatlib package is available in ```codeready-builder-for-rhel-8-x86_64-rpms``` and ```codeready-builder-for-rhel-9-x86_64-rpms``` repositories on RHEL8 and RHEL9 respectively. To enable this subscription required repository via buildconfig, please follow [link](https://docs.openshift.com/container-platform/4.13/cicd/builds/running-entitled-builds.html). 
 
 *	Build the workload container image
 
@@ -138,7 +138,7 @@ This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Refer
 ```
 
 
-* For all sample tests `./cpa_sample_code` 
+* For all sample tests `cpa_sample_code` 
 
 ```
 $ oc logs intel-qat-workload-c6g9v

--- a/tests/l2/qat/qatlib_build.yaml
+++ b/tests/l2/qat/qatlib_build.yaml
@@ -22,39 +22,26 @@ spec:
     type: Dockerfile
     dockerfile: |
         
-        FROM registry.access.redhat.com/ubi8/ubi 
-        ARG QATLIB_VERSION
-
-        RUN dnf -y update && \
-            dnf install -y gcc \
-              make \
-              automake \ 
-              autoconf \
-              libtool \
-              http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/nasm-2.15.03-3.el8.x86_64.rpm \
-              openssl-devel \
-              zlib-devel \
-              git && \
-              git clone -b $QATLIB_VERSION https://github.com/intel/qatlib
-            
-          RUN cd /qatlib && \
-              ./autogen.sh && \
-              ./configure \
-              --prefix=/usr \
-              --enable-systemd=no && \
-              make -j && \
-              make install samples-install
-
-          WORKDIR  /usr/bin
-          ENTRYPOINT  ["/usr/bin/cpa_sample_code"]
+          ARG BUILDER=registry.access.redhat.com/ubi9-minimal:latest
+          FROM ${BUILDER} 
+          RUN microdnf -y update && \
+            microdnf install -y qatlib-tests qatlib-devel qatlib --enablerepo=codeready-builder-for-rhel-9-x86_64-rpms
+          
   strategy:
     type: Docker
     noCache: true
     dockerStrategy:
       buildArgs:
-          - name: "QATLIB_VERSION"
-            value: "23.08.0"
-
+        - name: "BUILDER"
+          value: "registry.access.redhat.com/ubi9-minimal:9.2"
+      volumes:
+      - name: etc-pki-entitlement
+        mounts:
+        - destinationPath: /etc/pki/entitlement
+        source:
+          type: Secret
+          secret:
+            secretName: etc-pki-entitlement
   output:
     to:
       kind: ImageStreamTag

--- a/tests/l2/qat/qatlib_job.yaml
+++ b/tests/l2/qat/qatlib_job.yaml
@@ -14,7 +14,7 @@ spec:
       - name: intel-qat-job
         image: image-registry.openshift-image-registry.svc:5000/intel-qat/intel-qat-workload:latest
         imagePullPolicy: IfNotPresent
-        command: ["./cpa_sample_code"]
+        command: ["cpa_sample_code"]
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
- Updated qatlib buildconfig to ubi9 with dnf package instead of building from source
- Updated readme steps: qatlib package in codeready-builder-for-rhel repos, to enable repo via buildconfig- steps from https://docs.openshift.com/container-platform/4.13/cicd/builds/running-entitled-builds.html
- qatlib job command updated

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
