### PR TITLE
machine_configuration: Update readme

### DIFF
--- a/machine_configuration/README.md
+++ b/machine_configuration/README.md
@@ -1,11 +1,11 @@
 # Setting up Machine Configuration
 
 # Introduction
-Machine configuration operation is used to configure [Red Hat Enterprise Linux CoreOS (RHCOS)](https://docs.openshift.com/container-platform/4.12/architecture/architecture-rhcos.html) on each node in a RHOCP cluster.
+Machine configuration operation is used to configure [Red Hat Enterprise Linux CoreOS (RHCOS)](https://docs.openshift.com/container-platform/4.13/architecture/architecture-rhcos.html) on each node in a RHOCP cluster.
 
 [Machine config operator](https://github.com/openshift/machine-config-operator) (MCO) is provided by Red Hat to manage the operating system and machine configuration. In this project through the MCO, cluster administrators can configure and update the kernel to provision Intel Hardware features on the worker nodes.
 
-MCO is one of the technologies used in this project to manage the machine configuration. In current OCP-4.12, MCO might reboot the node to enable the machine configuration. Since rebooting the node is undesirable, alternative machine configuration technologies are under investigation. For more details, see this [issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/34).  
+MCO is one of the technologies used in this project to manage the machine configuration. In current OCP, MCO might reboot the node to enable the machine configuration. Since rebooting the node is undesirable, alternative machine configuration technologies are under investigation. For more details, see this [issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/34).  
 
 The best approach is to work with the RHCOS team to push the RHCOS configuration as the default configuration for a RHOCP cluster on [Day 0](https://www.ibm.com/cloud/architecture/content/course/red-hat-openshift-container-platform-day-2-ops/). 
 
@@ -16,7 +16,7 @@ If the configuration cannot be set as the default setting, we recommend using so
 Any contribution in this area is welcome. 
 
 # Prerequisites 
-- Provisioned RHOCP 4.12 cluster. Follow steps [here](/README.md#provisioning-rhocp-cluster).
+- Provisioned RHOCP cluster. Follow steps [here](/README.md#provisioning-rhocp-cluster).
 - Setup node feature discovery (NFD). Follow steps [here](/nfd/README.md).
 
 # General configuration 
@@ -70,12 +70,10 @@ intel-dgpu   rendered-intel-dgpu-58fb5f4d72fe6041abb066880e112acd   True      Fa
 ```
 Ensure `intel-dgpu` MachineConfigPool is present.
 
-# Disable conflicting driver
-Run the command shown below to disable the loading of a potential conflicting driver, such as `ast` driver.
-
-**Note**: The `i915` driver depends on a ported `drm` module. Some other drivers, such as ast that depends on in-tree drm module might have a compatibility issue. The known issue will be resolved on i915 driver for RHEL `9.x`, which will be used for RHOCP `4.13`. 
+# Disable in-tree drivers
+Run the command shown below to disable the loading of in-tree drivers 'i915' and 'intel_vsec'.
 ```
-$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/machine_configuration/100-intel-dgpu-machine-config-disable-ast.yaml
+$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/machine_configuration/100-intel-dgpu-machine-config-disable-intree-i915-vsec.yaml
 ```
 **Note**: This command will reboot the worker nodes in the `intel-dgpu` MachineConfigPool sequentially.
 
@@ -83,9 +81,10 @@ $ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-
 Navigate to the node terminal on the web console (Compute -> Nodes -> Select a node -> Terminal). Run the following commands in the terminal.
 ```
 $ chroot /host
-$ lsmod | grep ast
+$ lsmod | grep i915
+$ lsmod | grep intel_vsec
 ```
-Ensure that ast driver is not loaded.
+Ensure that the in-tree i915 and intel_vsec driver is not loaded.
 
 # Machine Configuration for Provisioning Intel® QAT
 


### PR DESCRIPTION
Disable the in-tree i915 and intel_vsec configuration so KMM can modprobe the
OOT drivers.
This is the short-term solution. In the long-run, the in-tree drivers unload should be handled by KMM operator.

Signed-off-by: Hersh Pathak hersh.pathak@intel.com