### PR TITLE
tests_l2: Update qatlib workload to ubi9 rpm packages

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -113,9 +113,11 @@ $ oc logs intel-dgpu-hwinfo-l4572
 ```                        
 
 ### Verify Intel® QuickAssist Technology provisioning
-This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Refer to the [qatlib readme](https://github.com/intel/qatlib/blob/main/INSTALL) for more details. 
+This workload runs [qatlib](https://github.com/intel/qatlib) sample tests using RedHat built and distributed Qatlib RPM packages from the codeready-builder-for-rhel-9-x86_64-rpms repo. Refer to the [qatlib readme](https://github.com/intel/qatlib/blob/main/INSTALL) for more details. 
 
 *	Build the workload container image
+
+Please replace the credentials in buildconfig yaml with your RedHat account login credentials. 
 
 ```$ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/l2/qat/qatlib_build.yaml ```
 
@@ -138,7 +140,7 @@ This workload runs [qatlib](https://github.com/intel/qatlib) sample tests. Refer
 ```
 
 
-* For all sample tests `./cpa_sample_code` 
+* For all sample tests `cpa_sample_code` 
 
 ```
 $ oc logs intel-qat-workload-c6g9v

--- a/tests/l2/qat/qatlib_build.yaml
+++ b/tests/l2/qat/qatlib_build.yaml
@@ -22,38 +22,21 @@ spec:
     type: Dockerfile
     dockerfile: |
         
-        FROM registry.access.redhat.com/ubi8/ubi 
-        ARG QATLIB_VERSION
-
-        RUN dnf -y update && \
-            dnf install -y gcc \
-              make \
-              automake \ 
-              autoconf \
-              libtool \
-              http://mirror.centos.org/centos/8-stream/PowerTools/x86_64/os/Packages/nasm-2.15.03-3.el8.x86_64.rpm \
-              openssl-devel \
-              zlib-devel \
-              git && \
-              git clone -b $QATLIB_VERSION https://github.com/intel/qatlib
-            
-          RUN cd /qatlib && \
-              ./autogen.sh && \
-              ./configure \
-              --prefix=/usr \
-              --enable-systemd=no && \
-              make -j && \
-              make install samples-install
-
-          WORKDIR  /usr/bin
-          ENTRYPOINT  ["/usr/bin/cpa_sample_code"]
+        ARG BUILDER=registry.access.redhat.com/ubi9:latest
+        FROM ${BUILDER} 
+        RUN subscription-manager register  --username=username --password=password && \
+            subscription-manager attach --auto && \
+            dnf repolist --disablerepo=* && \
+            subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms  && \
+            dnf -y update && \
+            dnf install -y  qatlib qatlib-tests
   strategy:
     type: Docker
     noCache: true
     dockerStrategy:
       buildArgs:
-          - name: "QATLIB_VERSION"
-            value: "23.08.0"
+          - name: "BUILDER"
+            value: "registry.access.redhat.com/ubi9:latest"
 
   output:
     to:

--- a/tests/l2/qat/qatlib_job.yaml
+++ b/tests/l2/qat/qatlib_job.yaml
@@ -14,7 +14,7 @@ spec:
       - name: intel-qat-job
         image: image-registry.openshift-image-registry.svc:5000/intel-qat/intel-qat-workload:latest
         imagePullPolicy: IfNotPresent
-        command: ["./cpa_sample_code"]
+        command: ["cpa_sample_code"]
         securityContext:
           capabilities:
             add:


### PR DESCRIPTION
- Updated qatlib buildconfig to ubi9 with rpm package instead of building from source
- Updated buildconfig, readme to use redhat account credentials for subscription-manager to install rpm packages from specific repos
- qatlib job command updated
- enhancements of entitlement builds and secret build inputs will be added in further releases

Signed-off-by: vbedida79 [veenadhari.bedida@intel.com](mailto:veenadhari.bedida@intel.com)