### PR TITLE
kmmo: Update intel-dgpu-on-premise-build module and filename

### DIFF
--- a/kmmo/intel-dgpu-on-premise-build.yaml
+++ b/kmmo/intel-dgpu-on-premise-build.yaml
@@ -13,7 +13,7 @@ spec: {}
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
-  name: intel-dgpu-on-premise-build-mode
+  name: intel-dgpu-on-premise-build
   namespace: openshift-kmm
 spec:
   moduleLoader:


### PR DESCRIPTION
Update module name and namespace to be <= 40 characters as required by KMM v2. Update filename to match shorter module name.

Signed-off-by: Hersh Pathak hersh.pathak@intel.com