### PR TITLE
tests_l2: Remove workaround for fixed issue #107

### DIFF
--- a/tests/l2/README.md
+++ b/tests/l2/README.md
@@ -32,9 +32,6 @@ $ oc logs intel-sgx-job-4tnh5
 ### Verify Intel® Data Center GPU provisioning
 #### clinfo
 This workload runs [clinfo](https://github.com/Oblomov/clinfo) utilizing the i915 resource from GPU provisioning and displays the related GPU information.
-* To work around [issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/107), please run the below command on the node with the GPU where your workload will run:
-  
-```$ setsebool container_use_devices on```
 
 *	Build the workload container image. 
 


### PR DESCRIPTION
Remove GPU workload workaround for https://github.com/intel/intel-technology-enabling-for-openshift/issues/107. Issue fixed in >= OCP 4.14.11 version

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>