### PR TITLE
device_plugins: Remove workaround for fixed issue #113

### DIFF
--- a/device_plugins/README.md
+++ b/device_plugins/README.md
@@ -3,8 +3,6 @@
 # Overview
 Intel Device Plugins are utilized to advertise Intel hardware features (resources) to a Red Hat OpenShift Container Platform (RHOCP) Cluster. This allows workloads running on pods deployed within the clusters to leverage these features. To handle the deployment and lifecycle of these device plugins, the [Intel Device Plugins Operator](https://catalog.redhat.com/software/container-stacks/detail/61e9f2d7b9cdd99018fc5736) is used. The Intel Device Plugins container images and operator have been officially certified and published on the [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/container-stacks/detail/61e9f2d7b9cdd99018fc5736). For more details on the upstream project, please refer to [Intel Device Plugins for Kubernetes](https://github.com/intel/intel-device-plugins-for-kubernetes).  
 
-**NOTE**: As the kubelet is running with incorrect label on OCP 4.13 and beyond, please follow the workaround section in the [incorrect kubelet label issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/113).
-
 # Prerequisities
 - Provisioned RHOCP cluster. Follow steps [here](/README.md).
 - Setup Node Feature Discovery (NFD). Follow steps [here](/nfd/README.md).


### PR DESCRIPTION
Remove workaround for https://github.com/intel/intel-technology-enabling-for-openshift/issues/113. Issue fixed in >= OCP 4.14.10 version. Refer to https://issues.redhat.com/browse/OCPBUGS-20022 for OCP 4.13 and 4.14 details

Signed-off-by: vbedida79 [veenadhari.bedida@intel.com](mailto:veenadhari.bedida@intel.com)