### PR TITLE
e2e: Update readme

### DIFF
--- a/e2e/inference/README.md
+++ b/e2e/inference/README.md
@@ -1,9 +1,7 @@
 # Overview
-Intel AI inference end-to-end solution with RHOCP is based on the Intel® Data Center GPU Flex Series provisioning, Intel® OpenVINO™, and [Red Hat OpenShift Data Science](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science) (RHODS) on RHOCP. There are two AI inference modes verified with Intel® Xeon® processors and Intel Data Center GPU Flex Series with RHOCP.
-* Interactive mode – RHODS provides OpenVINO based Jupyter Notebooks for users to interactively debug the inference applications or [optimize the models](https://docs.openvino.ai/2023.0/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) on RHOCP using data center GPU cards or Intel Xeon processors.
+Intel AI inference end-to-end solution with RHOCP is based on the Intel® Data Center GPU Flex Series provisioning, Intel® OpenVINO™, and [Red Hat OpenShift AI](https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-ai) (RHOAI) on RHOCP. There are two AI inference modes verified with Intel® Xeon® processors and Intel Data Center GPU Flex Series with RHOCP.
+* Interactive mode – RHOAI provides OpenVINO based Jupyter Notebooks for users to interactively debug the inference applications or [optimize the models](https://docs.openvino.ai/2023.0/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) on RHOCP using data center GPU cards or Intel Xeon processors.
 * Deployment mode – [OpenVINO Model Sever](https://github.com/openvinotoolkit/model_server) (OVMS) can be used to deploy the inference workloads in data center and edge computing environments on RHOCP.  
-
-**NOTE**: To ensure the AI inference workloads work properly, please follow the workaround section in the [known SeLinux regression issue](https://github.com/intel/intel-technology-enabling-for-openshift/issues/107).
 
 ## Prerequisites
 * Provisioned RHOCP cluster. Follow steps [here](/README.md#provisioning-rhocp-cluster)
@@ -13,26 +11,26 @@ Intel AI inference end-to-end solution with RHOCP is based on the Intel® Data C
   * Setup out of tree drivers for Intel GPU provisioning. Follow the steps [here](/kmmo/README.md)
   * Setup Intel device plugins operator and create Intel GPU device plugin. Follow the steps [here](/device_plugins/README.md)  
 
-## Install RHODS
-The Red Hat certified RHODS operator is published at [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/container-stacks/detail/63b85b573112fe5a95ee9a3a). You can use the command line interface (CLI) or web console to install it.
+## Install RHOAI
+The Red Hat certified RHOAI operator is published at [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/container-stacks/detail/63b85b573112fe5a95ee9a3a). You can use the command line interface (CLI) or web console to install it.
 ### Install using CLI (To be added)
 ### Install using web console
 1.	On the RHOCP web console, click Operators → OperatorHub.
-2.	Search RedHat OpenShift Data Science Operator and click Install. The operator is installed in the namespace redhat-ods-operator.
+2.	Search RedHat OpenShift AI Operator and click Install. The operator is installed in the namespace redhat-ods-operator.
 ### Verification
 1.	Navigate to Operators → Installed Operators page.
-2.	Ensure that in the redhat-ods-operator namespace, RedHat OpenShift Data Science Status is InstallSucceeded 
-3.	Click on ```Search -> Routes -> rhods-dashboard``` from the web console and access the RHODS UI link.
-Note: When installing the operator, the default ```kfdef``` Custom Resource (CR) is created. This CR enables the RHODS dashboard for users to browse and launch Jupyter Notebooks projects on an RHOCP cluster. Please refer to this [link](https://github.com/red-hat-data-services/odh-deployer) for more details about kfdef.
+2.	Ensure that in the redhat-ods-operator namespace, RedHat OpenShift AI status is InstallSucceeded 
+3.	Click on ```Search -> Routes -> rhods-dashboard``` from the web console and access the RHOAI UI link.
+Note: When installing the operator, the default ```kfdef``` Custom Resource (CR) is created. This CR enables the dashboard for users to browse and launch Jupyter Notebooks projects on an RHOCP cluster. Please refer to this [link](https://github.com/red-hat-data-services/odh-deployer) for more details about kfdef.
 ## Install OpenVINO operator
 The OpenVINO operator is published at [Red Hat Ecosystem Catalog](https://catalog.redhat.com/software/container-stacks/detail/60649a56209af65d24b7ca9e). You can use the CLI or web console to install it.
 ### Install using CLI (To be added)
 ### Install using web console
 Follow this [link](https://github.com/openvinotoolkit/operator/blob/v1.1.0/docs/operator_installation.md)  to install the operator via the web console. 
 ## Work with interactive mode
-To enable the interactive mode, the OpenVINO notebook CR needs to be created and integrated with RHODS.  
-1.	Click on the ```create Notebook``` option in this [link](https://github.com/red-hat-data-services/odh-deployer) from the web console and follow these [steps](https://github.com/openvinotoolkit/operator/blob/main/docs/notebook_in_rhods.md) to create the notebook CR.
-2.	Enable Intel Data Center GPU on RHODS Dashboard- **Technical Preview feature**
+To enable the interactive mode, the OpenVINO notebook CR needs to be created and integrated with RHOAI.  
+1.	Click on the ```create Notebook``` option from the web console and follow these [steps](https://github.com/openvinotoolkit/operator/blob/main/docs/notebook_in_rhods.md) to create the notebook CR.
+2.	Enable Intel Data Center GPU on RHOAI Dashboard- **Technical Preview feature**
 
 Create AcceleratoProfile in the ```redhat-ods-applications``` namespace 
 
@@ -42,7 +40,7 @@ Create AcceleratoProfile in the ```redhat-ods-applications``` namespace
 
 ![Alt text](/docs/images/openvino-accelerator-field.png)
 
-4. Navigate to ```Search -> Networking -> Routes``` from the web console and access ```rhods-dashboard``` route in the ```redhat-ods-applications``` namespace, as in the image below. Click on the location link to launch RHODS dashboard. 
+4. Navigate to ```Search -> Networking -> Routes``` from the web console and access ```rhods-dashboard``` route in the ```redhat-ods-applications``` namespace, as in the image below. Click on the location link to launch RHOAI dashboard. 
    
 ![Alt text](/docs/images/rhods-dashboard-route.png)
  


### PR DESCRIPTION
Updated e2e readme
- Red Hat OpenShift Data Science (RHODS) operator name to RedHat OpenShift AI (RHOAI)
- Remove workaround for for fixed issue #107. Addressed in #201 and issue fixed in OCP >= 4.14.11
- RHODS dashboard to RHOAI dashboard in doc
- documentation links

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>