### PR TITLE
kmmo: Remove in-tree module at runtime with KMM

### DIFF
--- a/kmmo/intel-dgpu.yaml
+++ b/kmmo/intel-dgpu.yaml
@@ -12,6 +12,7 @@ spec:
       modprobe:
         moduleName: i915
         firmwarePath: /firmware
+      inTreeModuleToRemove: intel_vsec
       kernelMappings:
         - regexp: '^.*\.x86_64$'
           containerImage: registry.connect.redhat.com/intel/intel-data-center-gpu-driver-container:2.2.0-$KERNEL_FULL_VERSION


### PR DESCRIPTION
Use KMM feature to remove in-tree intel_vsec at runtime. See link for more details: https://openshift-kmm.netlify.app/documentation/deploy_kmod/#replacing-an-in-tree-module Signed-off-by: Hersh Pathak hersh.pathak@intel.com