### PR TITLE
nfd: Add namespace for NodeFeatureRule

### DIFF
--- a/nfd/node-feature-rules-openshift.yaml
+++ b/nfd/node-feature-rules-openshift.yaml
@@ -5,6 +5,7 @@ apiVersion: nfd.openshift.io/v1alpha1
 kind: NodeFeatureRule
 metadata:
   name: intel-dp-devices
+  namespace: openshift-nfd
 spec:
   rules:
     - name: "intel.gpu"


### PR DESCRIPTION
Use explicit openshift-nfd namespace instead of implicit namespace which can vary based on which project user creates the CR. Signed-off-by: Hersh Pathak hersh.pathak@intel.com