### PR TITLE
 kmmo: Remove in-tree module at runtime with KMM on premise build mode

### DIFF
--- a/kmmo/intel-dgpu-on-premise-build.yaml
+++ b/kmmo/intel-dgpu-on-premise-build.yaml
@@ -22,6 +22,7 @@ spec:
       modprobe:
         moduleName: i915
         firmwarePath: /firmware
+      inTreeModuleToRemove: intel_vsec
       kernelMappings:
         - regexp: '^.*\.x86_64$'
           containerImage: image-registry.openshift-image-registry.svc:5000/openshift-kmm/intel-dgpu-driver-container-kmmo:$KERNEL_FULL_VERSION


### PR DESCRIPTION
Use KMM feature to remove in-tree intel_vsec at runtime. See link for more details: https://openshift-kmm.netlify.app/documentation/deploy_kmod/#replacing-an-in-tree-module Signed-off-by: Hersh Pathak hersh.pathak@intel.com