### PR TITLE
nfd: Update node feature rule for SGX

### DIFF
--- a/nfd/node-feature-rules-openshift.yaml
+++ b/nfd/node-feature-rules-openshift.yaml
@@ -32,14 +32,16 @@ spec:
     - name: "intel.sgx"
       labels:
         "intel.feature.node.kubernetes.io/sgx": "true"
+      extendedResources:
+        sgx.intel.com/epc: "@cpu.security.sgx.epc"
       matchFeatures:
         - feature: cpu.cpuid
           matchExpressions:
             SGX: {op: Exists}
             SGXLC: {op: Exists}
-        - feature: cpu.sgx
+        - feature: cpu.security
           matchExpressions:
-            enabled: {op: IsTrue}
+            sgx.enabled: {op: IsTrue}
         - feature: kernel.config
           matchExpressions:
             X86_SGX: {op: Exists}


### PR DESCRIPTION
Updated Node feature rule for SGX to use sgx.intel.com/epc as extended resource with NFD. This is verified on OCP 4.15 NFD version 4.15.0-202403101838. 
Node feature discovery for SGX EPC and SGX plugin init container would not longer be needed. 

Refer to upstream https://github.com/intel/intel-device-plugins-for-kubernetes/blob/v0.28.0/deployments/nfd/overlays/node-feature-rules/node-feature-rules.yaml

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
