### PR TITLE
nfd: Update NFD CR's to support SGX EPC

### DIFF
--- a/nfd/node-feature-discovery-openshift.yaml
+++ b/nfd/node-feature-discovery-openshift.yaml
@@ -7,12 +7,8 @@ metadata:
   name: nfd-instance
   namespace: openshift-nfd
 spec:
-  extraLabelNs:
-    - sgx.intel.com
-  resourceLabels:
-    - sgx.intel.com/epc
   operand:
-    image: quay.io/openshift/origin-node-feature-discovery:4.13
+    image: quay.io/openshift/origin-node-feature-discovery:4.15
     imagePullPolicy: Always
     servicePort: 12000
   workerConfig:

--- a/nfd/node-feature-rules-openshift.yaml
+++ b/nfd/node-feature-rules-openshift.yaml
@@ -32,14 +32,16 @@ spec:
     - name: "intel.sgx"
       labels:
         "intel.feature.node.kubernetes.io/sgx": "true"
+      extendedResources:
+        sgx.intel.com/epc: "@cpu.security.sgx.epc"
       matchFeatures:
         - feature: cpu.cpuid
           matchExpressions:
             SGX: {op: Exists}
             SGXLC: {op: Exists}
-        - feature: cpu.sgx
+        - feature: cpu.security
           matchExpressions:
-            enabled: {op: IsTrue}
+            sgx.enabled: {op: IsTrue}
         - feature: kernel.config
           matchExpressions:
             X86_SGX: {op: Exists}


### PR DESCRIPTION
Fixes https://github.com/intel/intel-technology-enabling-for-openshift/issues/255 
Removed SGX `extraLabelNs` and `resourceLabels` from NodeFeatureDiscovery CR. Added SGX EPC as  
```
extendedResources:
        sgx.intel.com/epc: "@cpu.security.sgx.epc" 
```
in the NodeFeatureRule CR.
With these changes, initContainer in SGXDevicePlugin CR wont be used (in Intel device plugins 0.29.0)
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>
