### PR TITLE
nfd: add nfd rule for DSA

### DIFF
--- a/nfd/node-feature-rules-openshift.yaml
+++ b/nfd/node-feature-rules-openshift.yaml
@@ -46,3 +46,15 @@ spec:
         - feature: kernel.config
           matchExpressions:
             X86_SGX: {op: Exists}
+    - name: "intel.dsa"
+      labels:
+        "intel.feature.node.kubernetes.io/dsa": "true"
+      matchFeatures:
+        - feature: pci.device
+          matchExpressions:
+            vendor: {op: In, value: ["8086"]}
+            device: {op: In, value: ["0b25"]}
+            class: {op: In, value: ["0880"]}
+        - feature: kernel.loadedmodule
+          matchExpressions:
+            idxd: {op: Exists}


### PR DESCRIPTION
Add NFD rule for DSA. Its based on PCI device id: 0b25 and in-tree driver idxd