### PR TITLE
MCO: add SVA support to iommu kernel boot parameters

### DIFF
--- a/machine_configuration/100-intel-iommu-on.yaml
+++ b/machine_configuration/100-intel-iommu-on.yaml
@@ -6,12 +6,13 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 100-intel-qat-intel-iommu-on
+  name: 100-intel-iommu-on
 spec:
   config:
     ignition:
       version: 3.2.0
   kernelArguments:
-      - intel_iommu=on modules_load=vfio-pci vfio-pci.ids=8086:4941,8086:4943
+      - intel_iommu=on,sm_on modules_load=vfio-pci vfio-pci.ids=8086:4941,8086:4943
   selector:
     intel.feature.node.kubernetes.io/qat: 'true'
+    intel.feature.node.kubernetes.io/dsa: 'true'


### PR DESCRIPTION
DSA requires sm_on to work properly. sm_on enables the IOMMU scalable mode.
This scalable mode is needed by DSA. More details on: https://cdrdv2-public.intel.com/759709/353216-data-streaming-accelerator-user-guide-003.pdf
We also removed qat from name as its used more multiple intel hardwares