### PR TITLE
nfd: update node feature discovery image to 4.16

### DIFF
--- a/nfd/node-feature-discovery-openshift.yaml
+++ b/nfd/node-feature-discovery-openshift.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-nfd
 spec:
   operand:
-    image: quay.io/openshift/origin-node-feature-discovery:4.15
+    image: quay.io/openshift/origin-node-feature-discovery:4.16
     imagePullPolicy: Always
     servicePort: 12000
   workerConfig:


### PR DESCRIPTION
updated node feature discovery image to 4.16 for 1.4.0 release
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>


