### PR TITLE
e2e_inference: update accelerator profile for Intel Gaudi

### DIFF
--- a/e2e/inference/accelerator_profile_gaudi.yaml
+++ b/e2e/inference/accelerator_profile_gaudi.yaml
@@ -3,7 +3,7 @@
 apiVersion: dashboard.opendatahub.io/v1
 kind: AcceleratorProfile
 metadata:
-  name: Intel Gaudi AI Accelerator
+  name: intel-gaudi-ai-accelerator
 spec:
   displayName: Intel Gaudi AI Accelerator
   description: Intel Gaudi AI Accelerator 


### PR DESCRIPTION
updated Intel Gaudi accelerator profile yaml to avoid upper case in the name for RHOAI
Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>