### PR TITLE
tests_gaudi: Updated namespace generic name to test gaudi workloads

### DIFF
--- a/tests/gaudi/l2/README.md
+++ b/tests/gaudi/l2/README.md
@@ -45,8 +45,8 @@ $ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-
 ```
 Create service account with required permissions: 
 ```
-$ oc create sa hccl-demo-anyuid-sa -n hccl-demo
-$ oc adm policy add-scc-to-user anyuid -z hccl-demo-anyuid-sa -n hccl-demo
+$ oc create sa hccl-demo-anyuid-sa -n gaudi-validation
+$ oc adm policy add-scc-to-user anyuid -z hccl-demo-anyuid-sa -n gaudi-validation
 ```
 Deploy and execute the workload:
 ```

--- a/tests/gaudi/l2/hccl_build.yaml
+++ b/tests/gaudi/l2/hccl_build.yaml
@@ -2,13 +2,13 @@ apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
   name: hccl-demo-workload
-  namespace: hccl-demo
+  namespace: gaudi-validation
 ---
 kind: BuildConfig
 apiVersion: build.openshift.io/v1
 metadata:
   name: hccl-demo-workload
-  namespace: hccl-demo
+  namespace: gaudi-validation
 spec:
   output:
     to:

--- a/tests/gaudi/l2/hccl_job.yaml
+++ b/tests/gaudi/l2/hccl_job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: hccl-demo-workload
-  namespace: hccl-demo
+  namespace: gaudi-validation
 spec:
   template:
     metadata:

--- a/tests/gaudi/l2/hl-smi_job.yaml
+++ b/tests/gaudi/l2/hl-smi_job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: hl-smi-workload
-  namespace: hl-smi-demo
+  namespace: gaudi-validation
 spec:
   template:
     metadata:


### PR DESCRIPTION
Updating the namespace to a generic namespace to run all workloads. This helps with easier implementation of one-click solution with ansible.

Signed-off-by: Chaitanya Kulkarni <chaitanya.kulkarni@intel.com>