### PR TITLE
tests_gaudi: update vllm workload for 1.19.1

### DIFF
--- a/tests/gaudi/l2/README.md
+++ b/tests/gaudi/l2/README.md
@@ -85,13 +85,8 @@ $ oc project gaudi-validation
 ```
 Build the workload container image:
 ```
-git clone https://github.com/HabanaAI/vllm-fork.git --branch v1.18.0
-
-cd vllm-fork/
-
 $ oc apply -f https://raw.githubusercontent.com/intel/intel-technology-enabling-for-openshift/main/tests/gaudi/l2/vllm_buildconfig.yaml
 
-$ oc start-build vllm-workload --from-dir=./ --follow
 ```
 Check if the build has completed
 ```

--- a/tests/gaudi/l2/vllm_buildconfig.yaml
+++ b/tests/gaudi/l2/vllm_buildconfig.yaml
@@ -22,7 +22,7 @@ spec:
     type: Dockerfile
     git:
         uri: https://github.com/HabanaAI/vllm-fork.git
-        ref: v0.6.4.post2+Gaudi-1.19.0
+        ref: v1.19.1
     dockerfile: |
         ARG BASE_IMAGE=vault.habana.ai/gaudi-docker/1.19.1/rhel9.4/habanalabs/pytorch-installer-2.5.1:1.19.1-26
         FROM ${BASE_IMAGE} as habana-base


### PR DESCRIPTION
- updated vllm buildconfig git ref to branch  v1.19.1, includes fix https://github.com/HabanaAI/vllm-fork/pull/727
- Readme instructions updated

Signed-off-by: vbedida79 <veenadhari.bedida@intel.com>