### PR TITLE
tests_l2: remove unused service account for vpl dsa workload

### DIFF
--- a/tests/l2/dgpu/intelvpl_job.yaml
+++ b/tests/l2/dgpu/intelvpl_job.yaml
@@ -19,4 +19,3 @@ spec:
           limits:
             gpu.intel.com/i915: 1
         imagePullPolicy: IfNotPresent
-      serviceAccountName: intel-dgpu


### PR DESCRIPTION
https://github.com/intel/intel-technology-enabling-for-openshift/tree/main/tests/l2/dgpu#using-libvpl this workload does not require any scc or rbac, so service account can be removed
Signed-off-by: Veenadhari Bedida <veenadhari.bedida@intel.com>