### PR TITLE
nfd: update node feature discovery cr

### DIFF
--- a/nfd/node-feature-discovery-openshift.yaml
+++ b/nfd/node-feature-discovery-openshift.yaml
@@ -8,7 +8,6 @@ metadata:
   namespace: openshift-nfd
 spec:
   operand:
-    image: quay.io/openshift/origin-node-feature-discovery:4.16
     imagePullPolicy: Always
     servicePort: 12000
   workerConfig:


### PR DESCRIPTION
node feature discovery operator by default pulls the correct image when nfd cr is deployed.
Previous (ocp version) nfd cr images were available on quay, from the latest releases the operator directly pulls the correct image needed. 

Signed-off-by: Veenadhari Bedida <veenadhari.bedida@intel.com>